### PR TITLE
[FEAT] Entry phase

### DIFF
--- a/operation/operation.py
+++ b/operation/operation.py
@@ -7,7 +7,6 @@ class Operation:
         self.operation_time = time()
         self.options = options
         self._entry_phase = entry_phase
-        self._phases = self.phases()
         self.current_phase = None
         self.break_phase = None
         self.fail_phase = None
@@ -17,9 +16,11 @@ class Operation:
 
     def run(self):
         try:
+            phases = self.phases()
             if self._entry_phase:
-                self._phases = self._phases[self._entry_phase.index(self._entry_phase):]
-            for phase in self._phases:
+                phases = phases[phases.index(self._entry_phase):]
+
+            for phase in phases:
                 self.current_phase = phase
                 getattr(self, phase)()
             self.success = True

--- a/operation/operation.py
+++ b/operation/operation.py
@@ -36,7 +36,7 @@ class Operation:
         return self
 
     def phases(self):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def break_operation(self, message=None):
         self.success = True

--- a/operation/operation.py
+++ b/operation/operation.py
@@ -3,9 +3,11 @@ from traceback import format_exc
 
 
 class Operation:
-    def __init__(self, options={}):
+    def __init__(self, options={}, entry_phase=None):
         self.operation_time = time()
         self.options = options
+        self._entry_phase = entry_phase
+        self._phases = self.phases()
         self.current_phase = None
         self.break_phase = None
         self.fail_phase = None
@@ -15,7 +17,9 @@ class Operation:
 
     def run(self):
         try:
-            for phase in self.phases():
+            if self._entry_phase:
+                self._phases = self._phases[self._entry_phase.index(self._entry_phase):]
+            for phase in self._phases:
                 self.current_phase = phase
                 getattr(self, phase)()
             self.success = True
@@ -31,7 +35,7 @@ class Operation:
         return self
 
     def phases(self):
-        NotImplementedError()
+        raise NotImplementedError()
 
     def break_operation(self, message=None):
         self.success = True

--- a/operation/operation.py
+++ b/operation/operation.py
@@ -1,8 +1,9 @@
 from time import time
 from traceback import format_exc
+from abc import ABC, abstractmethod
 
 
-class Operation:
+class Operation(ABC):
     def __init__(self, options={}, entry_phase=None):
         self.operation_time = time()
         self.options = options
@@ -18,7 +19,8 @@ class Operation:
         try:
             phases = self.phases()
             if self._entry_phase:
-                phases = phases[phases.index(self._entry_phase):]
+                start_phase = phases.index(self._entry_phase)
+                phases = phases[start_phase:]
 
             for phase in phases:
                 self.current_phase = phase
@@ -35,6 +37,7 @@ class Operation:
         self.operation_time = time() - self.operation_time
         return self
 
+    @abstractmethod
     def phases(self):
         raise NotImplementedError
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -28,8 +28,8 @@ class TestOperation(Operation):
             self.fail_phase()
 
 
-def run_operation(initial_options={}, phases=[]):
-    wo = TestOperation(initial_options)
+def run_operation(initial_options={}, phases=[], entry_phase=None):
+    wo = TestOperation(initial_options, entry_phase)
     if phases:
         wo.phases = lambda: phases
     return wo.run()
@@ -59,3 +59,10 @@ def test_fail_operation():
     assert 'option_for_second_phase' in wo.options
     assert wo.fail_phase is 'phase_test_fail'
     assert 'reached_third_phase' not in wo.options
+
+
+def test_entry_phase():
+    wo = run_operation(initial_options={'some_initial_options': 1}, entry_phase='phase_three')
+    assert wo.success is True
+    assert 'option_for_second_phase' not in wo.options
+    assert 'reached_third_phase' in wo.options

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -2,6 +2,7 @@ from operation import Operation
 
 
 class TestOperation(Operation):
+
     def phases(self):
         return [
             'phase_one',


### PR DESCRIPTION
New Feature - Entry Phase!
Now, we can allow the user to add an `entry_phase` with options, so we can resend the options to to the operation from the entry phase.

This can be extremely useful for re-sending events from a fail-queue feature.